### PR TITLE
[🍇 Assignment/#6] Week6_Seminar_실습과제 구현

### DIFF
--- a/practice/build.gradle
+++ b/practice/build.gradle
@@ -23,6 +23,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/practice/src/main/java/org/sopt/practice/auth/AuthController.java
+++ b/practice/src/main/java/org/sopt/practice/auth/AuthController.java
@@ -1,0 +1,38 @@
+package org.sopt.practice.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.practice.dto.request.LoginRequest;
+import org.sopt.practice.dto.request.RefreshTokenRequest;
+import org.sopt.practice.dto.response.LoginResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(
+            @RequestBody LoginRequest loginRequest
+    ){
+        LoginResponse loginResponse = authService.login(loginRequest);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(loginResponse);
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<LoginResponse> refresh(
+            @RequestBody RefreshTokenRequest refreshTokenRequest
+    ){
+        LoginResponse loginResponse = authService.refreshAccessToken(refreshTokenRequest);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(loginResponse);
+    }
+}

--- a/practice/src/main/java/org/sopt/practice/auth/AuthService.java
+++ b/practice/src/main/java/org/sopt/practice/auth/AuthService.java
@@ -1,0 +1,62 @@
+package org.sopt.practice.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.practice.auth.redis.domain.Token;
+import org.sopt.practice.auth.redis.repository.RedisTokenRepository;
+import org.sopt.practice.common.jwt.JwtTokenProvider;
+import org.sopt.practice.domain.Member;
+import org.sopt.practice.dto.request.LoginRequest;
+import org.sopt.practice.dto.request.RefreshTokenRequest;
+import org.sopt.practice.dto.response.LoginResponse;
+import org.sopt.practice.exception.NotFoundException;
+import org.sopt.practice.exception.enums.ErrorMessage;
+import org.sopt.practice.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTokenRepository redisTokenRepository;
+    private final MemberRepository memberRepository;
+
+    public LoginResponse login(LoginRequest loginRequest){
+        // 사용자의 자격 증명을 확인하는 로직
+        Member member = memberRepository.findByUsername(loginRequest.username())
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND_BY_ID_EXCEPTION));
+
+        // 아이디와 비밀번호가 일치하는지 확인하는 로직
+        if(!member.getPassword().equals(loginRequest.password())){
+            throw new NotFoundException(ErrorMessage.INVALID_MEMBER_PASSWORD_EXCEPTION);
+        }
+
+        Long memberId = member.getId();
+
+        String accessToken = jwtTokenProvider.issueAccessToken(
+                UserAuthentication.createUserAuthentication(memberId)
+        );
+
+        String refreshToken = jwtTokenProvider.issueRefreshToken(
+                UserAuthentication.createUserAuthentication(memberId)
+        );
+
+        //리프레시 토큰을 Redis에 저장
+        redisTokenRepository.save(Token.of(memberId, refreshToken));
+
+        return LoginResponse.of(accessToken, refreshToken);
+    }
+
+    public LoginResponse refreshAccessToken(RefreshTokenRequest refreshTokenRequest){
+        String refreshToken = refreshTokenRequest.refreshToken();
+        Token token = redisTokenRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.INVALID_REFRESH_TOKEN_EXCEPTION));
+
+        Long userId = token.getId();
+        String newAccessToken = jwtTokenProvider.issueRefreshToken(
+                UserAuthentication.createUserAuthentication(userId)
+        );
+
+        return LoginResponse.of(newAccessToken, refreshToken);
+    }
+}

--- a/practice/src/main/java/org/sopt/practice/auth/SecurityConfig.java
+++ b/practice/src/main/java/org/sopt/practice/auth/SecurityConfig.java
@@ -22,7 +22,15 @@ public class SecurityConfig {
     private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
-    private static final String[] AUTH_WHITE_LIST = {"/api/v1/member"};
+    private static final String[] AUTH_WHITE_LIST = {
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/v3/api-docs/**",
+            "/api/v1/member",
+            "/api/v1/auth/login",
+            "/api/v1/auth/refresh",
+            "/api/v1/member/find-all",
+    };
 
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/practice/src/main/java/org/sopt/practice/common/jwt/JwtTokenProvider.java
+++ b/practice/src/main/java/org/sopt/practice/common/jwt/JwtTokenProvider.java
@@ -19,12 +19,17 @@ public class JwtTokenProvider {
     private static final String USER_ID = "userId";
 
     private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 14;
+    private static final Long REFRESH_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 14;
 
     @Value("${jwt.secret}")
     private String JWT_SECRET;
 
     public String issueAccessToken(final Authentication authentication){
         return generateToken(authentication, ACCESS_TOKEN_EXPIRATION_TIME);
+    }
+
+    public String issueRefreshToken(final Authentication authentication){
+        return generateToken(authentication, REFRESH_TOKEN_EXPIRATION_TIME);
     }
 
     public String generateToken(Authentication authentication, Long tokenExpirationTime){
@@ -74,5 +79,4 @@ public class JwtTokenProvider {
         Claims claims = getBody(token);
         return Long.valueOf(claims.get(USER_ID).toString());
     }
-
 }

--- a/practice/src/main/java/org/sopt/practice/controller/MemberController.java
+++ b/practice/src/main/java/org/sopt/practice/controller/MemberController.java
@@ -11,7 +11,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -47,7 +46,7 @@ public class MemberController {
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("find-all")
+    @GetMapping("/find-all")
     public ResponseEntity<List<MemberFindAllDto>> findAllMembers(){
         List<Member> members = memberService.findAllMembers();
         List<MemberFindAllDto> memberFindAllDtoList = members.stream()

--- a/practice/src/main/java/org/sopt/practice/domain/Member.java
+++ b/practice/src/main/java/org/sopt/practice/domain/Member.java
@@ -15,7 +15,9 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY) //기본키 생성을 데이터베이스에 위임
     private Long id;
 
-    private String name;
+    private String username; // 유저 이름
+
+    private String password; // 유저 비밀번호
 
     @Enumerated(EnumType.STRING) //Enum의 이름을 데이터베이스에 저장
     private Part part;
@@ -23,9 +25,10 @@ public class Member {
     private int age;
 
 //    정적 팩토리 메서드로 객체 생성
-    public static Member create(String name, Part part, int age){
+    public static Member create(String name, String password, Part part, int age){
         return Member.builder()
-                .name(name)
+                .username(name)
+                .password(password)
                 .part(part)
                 .age(age)
                 .build();
@@ -33,8 +36,9 @@ public class Member {
 
     // 빌더패턴으로 객체 생성
     @Builder
-    private Member(final String name, final Part part, final int age){
-        this.name = name;
+    private Member(final String username, String password,final Part part, final int age){
+        this.username = username;
+        this.password = password;
         this.part = part;
         this.age = age;
     }

--- a/practice/src/main/java/org/sopt/practice/dto/request/LoginRequest.java
+++ b/practice/src/main/java/org/sopt/practice/dto/request/LoginRequest.java
@@ -1,0 +1,7 @@
+package org.sopt.practice.dto.request;
+
+public record LoginRequest(
+        String username,
+        String password
+) {
+}

--- a/practice/src/main/java/org/sopt/practice/dto/request/MemberCreateRequest.java
+++ b/practice/src/main/java/org/sopt/practice/dto/request/MemberCreateRequest.java
@@ -3,7 +3,8 @@ package org.sopt.practice.dto.request;
 import org.sopt.practice.domain.enums.Part;
 
 public record MemberCreateRequest(
-        String name,
+        String username,
+        String password,
         Part part,
         int age
 ) {

--- a/practice/src/main/java/org/sopt/practice/dto/request/RefreshTokenRequest.java
+++ b/practice/src/main/java/org/sopt/practice/dto/request/RefreshTokenRequest.java
@@ -1,0 +1,6 @@
+package org.sopt.practice.dto.request;
+
+public record RefreshTokenRequest(
+        String refreshToken
+) {
+}

--- a/practice/src/main/java/org/sopt/practice/dto/response/LoginResponse.java
+++ b/practice/src/main/java/org/sopt/practice/dto/response/LoginResponse.java
@@ -1,0 +1,13 @@
+package org.sopt.practice.dto.response;
+
+public record LoginResponse(
+        String accessToken,
+        String refreshToken
+) {
+    public static LoginResponse of(
+            String accessToken,
+            String refreshToken
+    ){
+        return new LoginResponse(accessToken, refreshToken);
+    }
+}

--- a/practice/src/main/java/org/sopt/practice/dto/response/MemberFindAllDto.java
+++ b/practice/src/main/java/org/sopt/practice/dto/response/MemberFindAllDto.java
@@ -12,6 +12,6 @@ public record MemberFindAllDto(
     public static MemberFindAllDto of(
             Member member
     ){
-        return new MemberFindAllDto(member.getName(), member.getPart(), member.getAge());
+        return new MemberFindAllDto(member.getUsername(), member.getPart(), member.getAge());
     }
 }

--- a/practice/src/main/java/org/sopt/practice/dto/response/MemberFindDto.java
+++ b/practice/src/main/java/org/sopt/practice/dto/response/MemberFindDto.java
@@ -12,6 +12,6 @@ public record MemberFindDto(
     public static MemberFindDto of(
             Member member
     ){
-        return new MemberFindDto(member.getName(), member.getPart(), member.getAge());
+        return new MemberFindDto(member.getUsername(), member.getPart(), member.getAge());
     }
 }

--- a/practice/src/main/java/org/sopt/practice/dto/response/UserJoinResponse.java
+++ b/practice/src/main/java/org/sopt/practice/dto/response/UserJoinResponse.java
@@ -2,12 +2,14 @@ package org.sopt.practice.dto.response;
 
 public record UserJoinResponse(
         String accessToken,
+        String refreshToken,
         String userId
 ) {
     public static UserJoinResponse of(
             String accessToken,
+            String refreshToken,
             String userId
     ){
-        return new UserJoinResponse(accessToken, userId);
+        return new UserJoinResponse(accessToken, refreshToken, userId);
     }
 }

--- a/practice/src/main/java/org/sopt/practice/exception/enums/ErrorMessage.java
+++ b/practice/src/main/java/org/sopt/practice/exception/enums/ErrorMessage.java
@@ -12,6 +12,8 @@ public enum ErrorMessage {
     MEMBER_NOT_OWNED_BLOG_EXCEPTION(HttpStatus.NOT_FOUND.value(), "블로그 소유자가 아닙니다."),
     POST_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(),  "ID에 해당하는 게시글이 존재하지 않습니다."),
     JWT_UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED.value(), "사용자의 로그인 검증을 실패했습니다."),
+    INVALID_MEMBER_PASSWORD_EXCEPTION(HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다."),
+    INVALID_REFRESH_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST.value(), "Refresh 토큰이 존재하지 않습니다."),
     ;
 
     private final int status;

--- a/practice/src/main/java/org/sopt/practice/external/SwaggerConfig.java
+++ b/practice/src/main/java/org/sopt/practice/external/SwaggerConfig.java
@@ -1,0 +1,21 @@
+package org.sopt.practice.external;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI(){
+        Info info = new Info()
+                .title("NOW SOPT PRACTICE SWAGGER")
+                .description("NOW SOPT 세미나 & 실습 API 구현")
+                .version("v1");
+
+        return new OpenAPI()
+                .info(info);
+    }
+}

--- a/practice/src/main/java/org/sopt/practice/repository/MemberRepository.java
+++ b/practice/src/main/java/org/sopt/practice/repository/MemberRepository.java
@@ -10,6 +10,6 @@ public interface MemberRepository extends Repository<Member, Long> {
     Member save(Member member);
     Optional<Member> findById(Long memberId);
     void delete(Member member);
-
     List<Member> findAll();
+    Optional<Member> findByUsername(String username);
 }


### PR DESCRIPTION
# 📄 Work Description

##  ✨ 로그인을 진행할 때 AccessToken과 Refresh Token을 함께 반환하는 로직 구현 ✨ <br/> ✨ Redis를 활용해 Refresh Token으로 Access Token을 재발급 받는 로직 구현 ✨

### 1️⃣ 회원가입 : JWT 인증 필터를 거치지 않음
- 회원가입 시 JWT 인증 필터를 거치지 않고, 사용자 정보를 저장하며 엑세스 토큰을 발급한다. 회원가입 API는 공개되어 있어야 하므로 인증 필터를 제외하고 구현한다.

### 2️⃣ 로그인 : JWT 인증 필터를 거치지 않음
- 로그인 시 사용자 자격 증명을 확인하고, 엑세스 토큰과 리프레시 토큰을 발급한다. 발급된 리프레시 토큰은 Redis에 저장하도록 구현한다.

### 3️⃣ 블로그 생성 : JWT 인증 필터를 거침
- 블로그 생성 API는 인증된 사용자만 접근할 수 있도록 JWT 인증 필터를 통과해야 한다.

### 4️⃣ 토큰 재발급 : JWT 인증 필터를 거치지 않음
- 리프레시 토큰을 사용하여 새로운 엑세스 토큰을 발급받는 API는 인증 필터를 거치지 않아야 한다.

---

### 📋 회원가입 및 로그인 시 토큰 발급 및 저장

- [x] 회원가입 시 Refresh Token을 발급할 수 있도록 UserJoinResponse에 코드 추가하기
- [x] MemberService 수정하기
- [x] JwtTokenProvider에 Refresh Token 관련 코드 추가하기
- [x] 로그인 로직 구현을 위한 LoginRequest, LoginResponse (record 형식) 구현하기
- [x] 로그인 시 사용자의 자격을 확인하는 비즈니스 로직(AuthService) 구현하기
- [x] AuthController 구현하기 
- [x] Postman으로 API 테스트 하기

### 📁 블로그 생성 시 JWT 인증 필터를 거치도록 구현

- [x] SecurityConfig에서 JWT 인증을 거치지 않는 주소를 AUTH_WHITE_LIST에 추가하기(Swagger 주소 포함)

### 📋 Redis를 활용해 Refresh Token으로 Access Token을 재발급 받는 로직 구현

- [x] RefreshTokenRequest 구현하기
- [x] Refresh Token 재발급 받는 비즈니스 로직(AuthService)과, 추가적으로 존재하는 토큰인지 확인하는 에러처리를 추가하여 구현하기
- [x] AuthController에 Refresh Token 재발급 관련 코드 추가하기 

---
# 📷 Screenshot

## 클래스 구조
<img width="514" alt="image" src="https://github.com/NOW-SOPT-SERVER/junggyo1020/assets/150939763/9311d75f-8395-47f4-8b80-f13d1a9620ba">
<img width="499" alt="image" src="https://github.com/NOW-SOPT-SERVER/junggyo1020/assets/150939763/6a6f53cd-4e39-427a-b191-f1e327d5ea9e">

## 📋 회원가입 및 로그인 시 토큰 발급 및 저장
### 1. 회원가입 시 Refresh Token을 발급할 수 있도록 UserJoinResponse에 코드 추가하기
<img width="942" alt="image" src="https://github.com/NOW-SOPT-SERVER/junggyo1020/assets/150939763/fa6e15ea-4932-4832-ad12-7f3b5f44cba3">

### 2. MemberService 수정하기(refreshToken 관련 로직 + 멤버 가입 시 password도 함께 받아오도록 코드 추가)
<img width="790" alt="image" src="https://github.com/NOW-SOPT-SERVER/junggyo1020/assets/150939763/43eb3a88-4e06-417e-9788-60e992acba87">

### 3. JwtTokenProvider에 Refresh Token 관련 코드 추가하기
<img width="942" alt="image" src="https://github.com/NOW-SOPT-SERVER/junggyo1020/assets/150939763/777cd4dd-d74b-430d-bfa9-f22c520dafd0">

### 4. 로그인 로직 구현을 위한 LoginRequest, LoginResponse (record 형식) 구현하기
<img width="953" alt="image" src="https://github.com/NOW-SOPT-SERVER/junggyo1020/assets/150939763/0a1e3081-9313-46be-9221-c273c26e3148">
<img width="956" alt="image" src="https://github.com/NOW-SOPT-SERVER/junggyo1020/assets/150939763/0c7942b9-3516-4d03-974f-e45191d2c7b2">

### 5. 로그인 시 사용자의 자격을 확인하는 비즈니스 로직(AuthService) 구현하기
<img width="946" alt="image" src="https://github.com/NOW-SOPT-SERVER/junggyo1020/assets/150939763/87d69236-e547-4653-9d39-e37bfb615085">

### 6. AuthController 구현하기 
<img width="950" alt="image" src="https://github.com/NOW-SOPT-SERVER/junggyo1020/assets/150939763/aee17d45-3fe0-4b90-a984-11c63c32a093">

## 📋 Redis를 활용해 Refresh Token으로 Access Token을 재발급 받는 로직 구현
### RefreshTokenRequest 구현하기
<img width="952" alt="image" src="https://github.com/NOW-SOPT-SERVER/junggyo1020/assets/150939763/42f31695-e4c4-4884-9db3-52f7c1855fae">

### 1. Refresh Token 재발급 받는 비즈니스 로직(AuthService)과, 추가적으로 존재하는 토큰인지 확인하는 예외처리를 추가하여 구현하기
<img width="952" alt="image" src="https://github.com/NOW-SOPT-SERVER/junggyo1020/assets/150939763/e80f0f26-d723-4808-a877-13e51a6ede8f">

### 2. AuthController에 Refresh Token 재발급 관련 코드 추가하기 
<img width="952" alt="image" src="https://github.com/NOW-SOPT-SERVER/junggyo1020/assets/150939763/3f227300-d458-48e6-8380-8477f46bb74d">


## 예외처리
### exception 구조
<img width="433" alt="image" src="https://github.com/NOW-SOPT-SERVER/junggyo1020/assets/150939763/bc1d1a8d-2177-4522-a0ac-d12197eecbdb">

### ErrorMessage.java
<img width="956" alt="image" src="https://github.com/NOW-SOPT-SERVER/junggyo1020/assets/150939763/10f55fa7-758e-40d5-996c-a68887deab9b">

## Swagger 테스트
### 1. 멤버 생성 시 RefreshToken도 함께 반환
<img width="1424" alt="image" src="https://github.com/NOW-SOPT-SERVER/junggyo1020/assets/150939763/c9b158f9-6190-41e4-b900-5d43949bacab">

### 2. 로그인 시 사용자 이름이 존재하지 않는 경우
<img width="1422" alt="image" src="https://github.com/NOW-SOPT-SERVER/junggyo1020/assets/150939763/0eab4ca7-689f-46c1-843c-14ff4d0c93a5">

### 3. 로그인 시 비밀번호가 일치하지 않는 경우
<img width="1424" alt="image" src="https://github.com/NOW-SOPT-SERVER/junggyo1020/assets/150939763/cef166de-3b99-4808-a156-c214721e5709">

### 4. 로그인 성공
<img width="1422" alt="image" src="https://github.com/NOW-SOPT-SERVER/junggyo1020/assets/150939763/2d06c124-afe7-4b01-8060-32e0800befe4">

### 5. Refresh Token이 존재하지 않는 경우
<img width="1423" alt="image" src="https://github.com/NOW-SOPT-SERVER/junggyo1020/assets/150939763/3dc80ea3-66da-4747-a801-214f3a078b8b">

### 6. Refresh Token 재발급 성공
<img width="1420" alt="image" src="https://github.com/NOW-SOPT-SERVER/junggyo1020/assets/150939763/f99e0045-e3be-4c74-bd36-073051ea6086">


```
# 💬 To Reviewer
- 6주차 내용이 많고 어려워서 좀 더 완벽하게 이해한 후에 진행을 하려다보니 시간이 좀 오래 걸렸습니다
- Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed:
  org.springframework.data.redis.RedisConnectionFailureException: Unable to connect to Redis] with root cause 
  이런 에러가 떠서 보니 redis-server로 실행을 안하고 진행을 해서 생긴 오류인것을 뒤늦게 깨달았습니다ㅎㅎ;;; 
  여러분은 꼭 redis-cli ping으로 redis 실행 여부 확인해보시길...
- 저는 Swagger 를 붙여서 진행했는데 처음에는 Swagger자체가 인증이 안되어있어서 접속이 불가한 에러가 생겼었는데요. 
  그래서 저는 Swagger관련 주소를 모두 Auth_WHITE_LIST에 추가하였습니다..!
- 코드에 에러나 궁금한점, 혹은 더 좋은 개선방안이 있다면 언제든지 코멘트 남겨주세요!!! 감사합니다🐶
```

